### PR TITLE
Fix Broken Meta Descriptions on Slides

### DIFF
--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -6,42 +6,42 @@
   </url>
   <url>
     <loc>https://vladislav-morozov.github.io/econometrics-2/slides/vector/ols-limit-distribution.html</loc>
-    <lastmod>2025-05-19T11:55:42.620Z</lastmod>
+    <lastmod>2025-05-19T15:35:43.468Z</lastmod>
   </url>
   <url>
     <loc>https://vladislav-morozov.github.io/econometrics-2/slides/vector/ols-delta-method.html</loc>
-    <lastmod>2025-05-19T11:55:42.619Z</lastmod>
+    <lastmod>2025-05-19T15:36:28.670Z</lastmod>
   </url>
   <url>
     <loc>https://vladislav-morozov.github.io/econometrics-2/slides/vector/identification-inference.html</loc>
-    <lastmod>2025-05-19T11:55:42.617Z</lastmod>
+    <lastmod>2025-05-19T15:37:09.677Z</lastmod>
   </url>
   <url>
     <loc>https://vladislav-morozov.github.io/econometrics-2/index.html</loc>
-    <lastmod>2025-05-19T12:12:10.938Z</lastmod>
+    <lastmod>2025-05-19T15:21:45.661Z</lastmod>
   </url>
   <url>
     <loc>https://vladislav-morozov.github.io/econometrics-2/exercises/exercises-linear-asymptotic.html</loc>
-    <lastmod>2025-05-19T11:55:42.617Z</lastmod>
+    <lastmod>2025-05-19T15:21:45.659Z</lastmod>
   </url>
   <url>
     <loc>https://vladislav-morozov.github.io/econometrics-2/exercises/exercises-linear-inference.html</loc>
-    <lastmod>2025-05-19T11:55:42.617Z</lastmod>
+    <lastmod>2025-05-19T15:21:45.661Z</lastmod>
   </url>
   <url>
     <loc>https://vladislav-morozov.github.io/econometrics-2/slides/organizational/intro.html</loc>
-    <lastmod>2025-05-19T11:55:42.617Z</lastmod>
+    <lastmod>2025-05-19T15:34:10.270Z</lastmod>
   </url>
   <url>
     <loc>https://vladislav-morozov.github.io/econometrics-2/slides/vector/ols-consistency.html</loc>
-    <lastmod>2025-05-19T11:55:42.619Z</lastmod>
+    <lastmod>2025-05-19T15:36:55.207Z</lastmod>
   </url>
   <url>
     <loc>https://vladislav-morozov.github.io/econometrics-2/slides/vector/ols-inference.html</loc>
-    <lastmod>2025-05-19T13:21:26.378Z</lastmod>
+    <lastmod>2025-05-19T15:36:10.414Z</lastmod>
   </url>
   <url>
     <loc>https://vladislav-morozov.github.io/econometrics-2/slides/vector/vector-ols.html</loc>
-    <lastmod>2025-05-19T11:55:42.620Z</lastmod>
+    <lastmod>2025-05-19T15:34:13.274Z</lastmod>
   </url>
 </urlset>

--- a/docs/slides/organizational/intro.qmd
+++ b/docs/slides/organizational/intro.qmd
@@ -4,6 +4,9 @@ subtitle: "Advanced Econometrics"
 author: Vladislav Morozov  
 format:
   revealjs:
+    include-in-header: 
+      text: |
+        <meta name="description" content="Course introduction for advanced econometrics (econometrics 2), covering course overview, logistics, and reference books (lecture notes slides)."/> 
     width: 1150
     slide-number: true
     sc-sb-title: true
@@ -26,7 +29,6 @@ filters:
 embed-resources: true
 include-in-header: ../../themes/mathjax.html 
 highlight-style: tango
-description: "Course introduction for advanced econometrics (econometrics 2), covering course overview, logistics, and reference books (lecture notes slides)."
 open-graph:
     description: "Course introduction for advanced econometrics (econometrics 2), covering course overview, logistics, and reference books (lecture notes slides)." 
 ---

--- a/docs/slides/vector/identification-inference.html
+++ b/docs/slides/vector/identification-inference.html
@@ -475,6 +475,7 @@
     };
 
   </script>
+  <meta name="description" content="Explore the basics of identification, estimation, and inference: definitions, parametric models, and linear model identification (lecture notes slides).">
 <meta property="og:title" content="Identification, Estimation and Inference – Advanced Econometrics">
 <meta property="og:description" content="Explore the basics of identification, estimation, and inference: definitions, parametric models, and linear model identification (lecture notes slides).">
 <meta property="og:site_name" content="Advanced Econometrics">
@@ -752,7 +753,7 @@ F_Y(y|\theta) \neq F_Y(y|\theta_0)
 </section>
 <section id="visual-example-difference-in-distributions" class="slide level4">
 <h4>Visual Example: Difference in Distributions</h4>
-<div id="d3bfeeb6" class="cell" data-execution_count="2">
+<div id="b155cc63" class="cell" data-execution_count="2">
 <div class="cell-output cell-output-display">
 <div>
 <figure>
@@ -781,7 +782,7 @@ F_Y(y|\theta) \neq F_Y(y|\theta_0)
 </section>
 <section id="visual-illustration-same-distribution" class="slide level4">
 <h4>Visual Illustration: Same Distribution</h4>
-<div id="a9e5fcc9" class="cell" data-execution_count="3">
+<div id="e9b1b263" class="cell" data-execution_count="3">
 <div class="cell-output cell-output-display">
 <div>
 <figure>

--- a/docs/slides/vector/identification-inference.qmd
+++ b/docs/slides/vector/identification-inference.qmd
@@ -4,6 +4,9 @@ subtitle: "The Three Parts of Statistics"
 author: Vladislav Morozov  
 format:
   revealjs:
+    include-in-header: 
+      text: |
+        <meta name="description" content="Explore the basics of identification, estimation, and inference: definitions, parametric models, and linear model identification (lecture notes slides)."/> 
     width: 1150
     slide-number: true
     sc-sb-title: true

--- a/docs/slides/vector/ols-consistency.html
+++ b/docs/slides/vector/ols-consistency.html
@@ -475,6 +475,7 @@
     };
 
   </script>
+  <meta name="description" content="Learn about the consistency of the OLS estimator: definitions, intuition, proof of consistency in model-free and causal frameworks (lecture notes slides).">
 <meta property="og:title" content="Consistency of the OLS Estimator – Advanced Econometrics">
 <meta property="og:description" content="Learn about the consistency of the OLS estimator: definitions, intuition, proof of consistency in model-free and causal frameworks (lecture notes slides).">
 <meta property="og:site_name" content="Advanced Econometrics">

--- a/docs/slides/vector/ols-consistency.qmd
+++ b/docs/slides/vector/ols-consistency.qmd
@@ -4,6 +4,9 @@ subtitle: "Convergence as Sample Size Grows"
 author: Vladislav Morozov  
 format:
   revealjs:
+    include-in-header: 
+      text: |
+        <meta name="description" content="Learn about the consistency of the OLS estimator: definitions, intuition, proof of consistency in model-free and causal frameworks (lecture notes slides)."/> 
     width: 1150
     slide-number: true
     sc-sb-title: true
@@ -24,8 +27,7 @@ title-slide-attributes:
 filters:
   - reveal-header  
 include-in-header: ../../themes/mathjax.html 
-highlight-style: tango
-description: "Learn about the consistency of the OLS estimator: definitions, intuition, proof of consistency in model-free and causal frameworks (lecture notes slides)."
+highlight-style: tango 
 open-graph:
     description: "Learn about the consistency of the OLS estimator: definitions, intuition, proof of consistency in model-free and causal frameworks (lecture notes slides)." 
 ---

--- a/docs/slides/vector/ols-delta-method.html
+++ b/docs/slides/vector/ols-delta-method.html
@@ -539,11 +539,9 @@
 
   </script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js" integrity="sha512-c3Nl8+7g4LMSTdrm621y7kf9v3SDPnhxLNhcjFJbKECVnmZHTdo+IRO05sNLTH/D3vA6u1X32ehoLC7WFVdheg==" crossorigin="anonymous"></script>
-
   
-
   <script type="application/javascript">define('jquery', [],function() {return window.jQuery;})</script>
-
+  <meta name="description" content="Explore the delta method for nonlinear functions of parameters: asymptotic distribution, confidence intervals, hypothesis testing (lecture notes slides).">
 <meta property="og:title" content="Inference II: Nonlinear Hypotheses – Advanced Econometrics">
 <meta property="og:description" content="Explore the delta method for nonlinear functions of parameters: asymptotic distribution, confidence intervals, hypothesis testing (lecture notes slides).">
 <meta property="og:site_name" content="Advanced Econometrics">
@@ -627,7 +625,7 @@ Vladislav Morozov
 <h4>Reminder: Estimation Results</h4>
 <div class="sourceCode" id="cb1" data-code-line-numbers="0-1"><pre class="sourceCode numberSource python number-lines code-with-copy"><code class="sourceCode python"><span id="cb1-1"><a></a>results <span class="op">=</span> OLS(endog, exog).fit(cov_type<span class="op">=</span><span class="st">'HC0'</span>) <span class="co"># Robust covariance matrix estimator</span></span>
 <span id="cb1-2"><a></a><span class="bu">print</span>(results.summary())</span></code><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></pre></div>
-<div id="33cf6548" class="cell" data-execution_count="1">
+<div id="689ec111" class="cell" data-execution_count="1">
 <div class="cell-output cell-output-stdout">
 <pre><code>                            OLS Regression Results                            
 ==============================================================================
@@ -635,7 +633,7 @@ Dep. Variable:               log_wage   R-squared:                       0.226
 Model:                            OLS   Adj. R-squared:                  0.226
 Method:                 Least Squares   F-statistic:                     862.5
 Date:                Mon, 19 May 2025   Prob (F-statistic):               0.00
-Time:                        12:55:06   Log-Likelihood:                -8152.9
+Time:                        17:37:41   Log-Likelihood:                -8152.9
 No. Observations:               10402   AIC:                         1.631e+04
 Df Residuals:                   10398   BIC:                         1.634e+04
 Df Model:                           3                                         
@@ -918,7 +916,7 @@ S = \left[ \dfrac{\hat{\beta}_1}{\hat{\beta_2}} - z_{1-\alpha/2} \sqrt{\dfrac{\w
 <section id="documentation-of-nonlineardeltacov" class="slide level4 scrollable">
 <h4>Documentation of <code>NonlinearDeltaCov</code></h4>
 <p>Functionality not documented, but <a href="https://github.com/statsmodels/statsmodels/blob/main/statsmodels/stats/_delta_method.py">in code</a> with good docstrings</p>
-<div id="1a910186" class="cell" data-execution_count="2">
+<div id="f384add5" class="cell" data-execution_count="2">
 <div class="sourceCode cell-code" id="cb3"><pre class="sourceCode numberSource python number-lines code-with-copy"><code class="sourceCode python"><span id="cb3-1"><a></a><span class="im">from</span> statsmodels.stats._delta_method <span class="im">import</span> NonlinearDeltaCov</span>
 <span id="cb3-2"><a></a><span class="bu">help</span>(NonlinearDeltaCov)</span></code><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></pre></div>
 <div class="cell-output cell-output-stdout">
@@ -1109,14 +1107,14 @@ class NonlinearDeltaCov(builtins.object)
 <section id="creating-an-instance-of-nonlineardeltacov" class="slide level4">
 <h4>Creating an Instance of <code>NonlinearDeltaCov</code></h4>
 <p>In our example, define the function <span class="math inline">\(a(\cdot)\)</span>:</p>
-<div id="e0add94d" class="cell" data-execution_count="3">
+<div id="0c0c05bf" class="cell" data-execution_count="3">
 <div class="sourceCode cell-code" id="cb5"><pre class="sourceCode numberSource python number-lines code-with-copy"><code class="sourceCode python"><span id="cb5-1"><a></a><span class="kw">def</span> max_earn(beta: pd.Series):</span>
 <span id="cb5-2"><a></a>    <span class="cf">return</span> np.array([<span class="op">-</span><span class="dv">50</span><span class="op">*</span>beta.loc[<span class="st">"experience"</span>]<span class="op">/</span>beta.loc[<span class="st">"experience_sq_div"</span>]])</span></code><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></pre></div>
 </div>
 <div class="fragment">
 <p><br></p>
 <p>Then we supply <span class="math inline">\(a(\cdot)\)</span> together with parameters and standard errors:</p>
-<div id="7f26c8a7" class="cell" data-execution_count="4">
+<div id="21fae2d5" class="cell" data-execution_count="4">
 <div class="sourceCode cell-code" id="cb6"><pre class="sourceCode numberSource python number-lines code-with-copy"><code class="sourceCode python"><span id="cb6-1"><a></a>delta_ratio <span class="op">=</span> NonlinearDeltaCov(max_earn, results.params, results.cov_params())</span></code><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></pre></div>
 </div>
 </div>
@@ -1124,14 +1122,14 @@ class NonlinearDeltaCov(builtins.object)
 <section id="constructing-cis-with-nonlineardeltacov" class="slide level4">
 <h4>Constructing CIs with <code>NonlinearDeltaCov</code></h4>
 <p>Can construct a 95% confidence interval with the <code>conf_int()</code> method</p>
-<div id="fa2f865b" class="cell" data-execution_count="5">
+<div id="2a005b0d" class="cell" data-execution_count="5">
 <div class="sourceCode cell-code" id="cb7"><pre class="sourceCode numberSource python number-lines code-with-copy"><code class="sourceCode python"><span id="cb7-1"><a></a>delta_ratio.conf_int(alpha<span class="op">=</span><span class="fl">0.05</span>)</span></code><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></pre></div>
 <div class="cell-output cell-output-display" data-execution_count="5">
 <pre><code>array([[30.36791181, 35.41407441]])</code></pre>
 </div>
 </div>
 <p>or the <code>summary()</code> method</p>
-<div id="467961dd" class="cell" data-execution_count="6">
+<div id="e9c6d2a4" class="cell" data-execution_count="6">
 <div class="sourceCode cell-code" id="cb9"><pre class="sourceCode numberSource python number-lines code-with-copy"><code class="sourceCode python"><span id="cb9-1"><a></a>delta_ratio.summary(alpha<span class="op">=</span><span class="fl">0.1</span>)</span></code><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></pre></div>
 <div class="cell-output cell-output-display" data-execution_count="6">
 <table class="simpletable caption-top" data-quarto-postprocess="true">
@@ -1236,7 +1234,7 @@ W = N\ba(\hat{\bbeta})'\left( \bA(\hat{\bbeta})\widehat{\avar}(\hat{\bbeta})\bA(
 <section id="illustration-nonlinear-wald-test-with-statsmodels" class="slide level4">
 <h4>Illustration: Nonlinear Wald Test with <code>statsmodels</code></h4>
 <p>Can do the Wald test with the <code>wald_test</code> method of <code>NonlinearDeltaCov</code>:</p>
-<div id="2aad7e8e" class="cell" data-execution_count="7">
+<div id="5fe4e561" class="cell" data-execution_count="7">
 <div class="sourceCode cell-code" id="cb10"><pre class="sourceCode numberSource python number-lines code-with-copy"><code class="sourceCode python"><span id="cb10-1"><a></a>delta_ratio.wald_test(np.array([<span class="dv">15</span>]))</span></code><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></pre></div>
 <div class="cell-output cell-output-display" data-execution_count="7">
 <pre><code>(np.float64(193.1535027123987), np.float64(6.516561763470986e-44))</code></pre>

--- a/docs/slides/vector/ols-delta-method.qmd
+++ b/docs/slides/vector/ols-delta-method.qmd
@@ -4,6 +4,9 @@ subtitle: "Handling Nonlinearities with the Delta Method"
 author: Vladislav Morozov   
 format:
   revealjs:
+    include-in-header: 
+      text: |
+        <meta name="description" content="Explore the delta method for nonlinear functions of parameters: asymptotic distribution, confidence intervals, hypothesis testing (lecture notes slides)."/> 
     width: 1150
     slide-number: true
     sc-sb-title: true
@@ -24,8 +27,7 @@ title-slide-attributes:
 filters:
   - reveal-header  
 include-in-header: ../../themes/mathjax.html 
-highlight-style: tango
-description: "Explore the delta method for nonlinear functions of parameters: asymptotic distribution, confidence intervals, hypothesis testing (lecture notes slides)."
+highlight-style: tango 
 open-graph:
     description: "Explore the delta method for nonlinear functions of parameters: asymptotic distribution, confidence intervals, hypothesis testing (lecture notes slides)." 
 ---

--- a/docs/slides/vector/ols-inference.html
+++ b/docs/slides/vector/ols-inference.html
@@ -541,6 +541,7 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js" integrity="sha512-c3Nl8+7g4LMSTdrm621y7kf9v3SDPnhxLNhcjFJbKECVnmZHTdo+IRO05sNLTH/D3vA6u1X32ehoLC7WFVdheg==" crossorigin="anonymous"></script>
   
   <script type="application/javascript">define('jquery', [],function() {return window.jQuery;})</script>
+  <meta name="description" content="Explore testing linear hypotheses and constructing confidence intervals: t-tests, Wald tests, and asymptotic confidence intervals (lecture notes slides).">
 <meta property="og:title" content="Inference I: Linear Hypotheses – Advanced Econometrics">
 <meta property="og:description" content="Explore testing linear hypotheses and constructing confidence intervals: t-tests, Wald tests, and asymptotic confidence intervals (lecture notes slides).">
 <meta property="og:site_name" content="Advanced Econometrics">
@@ -620,7 +621,7 @@ Vladislav Morozov
 \tag{1}\]</span></span></p>
 <div class="fragment">
 <p>Data: married white women from March 2009 CPS</p>
-<div id="9d2e8cd5" class="cell" data-execution_count="1">
+<div id="f4826114" class="cell" data-execution_count="1">
 <details class="code-fold">
 <summary>Expand for full data preparation code</summary>
 <div class="sourceCode cell-code" id="cb1"><pre class="sourceCode numberSource python number-lines code-with-copy"><code class="sourceCode python"><span id="cb1-1"><a></a><span class="im">import</span> numpy <span class="im">as</span> np</span>
@@ -660,7 +661,7 @@ Vladislav Morozov
 <h4>Reminder: Estimation Results</h4>
 <div class="sourceCode" id="cb2" data-code-line-numbers="0-1"><pre class="sourceCode numberSource python number-lines code-with-copy"><code class="sourceCode python"><span id="cb2-1"><a></a>results <span class="op">=</span> OLS(endog, exog).fit(cov_type<span class="op">=</span><span class="st">'HC0'</span>) <span class="co"># Robust covariance matrix estimator</span></span>
 <span id="cb2-2"><a></a><span class="bu">print</span>(results.summary())</span></code><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></pre></div>
-<div id="68b5d588" class="cell" data-execution_count="2">
+<div id="952e3671" class="cell" data-execution_count="2">
 <div class="cell-output cell-output-stdout">
 <pre><code>                            OLS Regression Results                            
 ==============================================================================
@@ -668,7 +669,7 @@ Dep. Variable:               log_wage   R-squared:                       0.226
 Model:                            OLS   Adj. R-squared:                  0.226
 Method:                 Least Squares   F-statistic:                     862.5
 Date:                Mon, 19 May 2025   Prob (F-statistic):               0.00
-Time:                        15:21:55   Log-Likelihood:                -8152.9
+Time:                        17:37:44   Log-Likelihood:                -8152.9
 No. Observations:               10402   AIC:                         1.631e+04
 Df Residuals:                   10398   BIC:                         1.634e+04
 Df Model:                           3                                         
@@ -936,7 +937,7 @@ t = \dfrac{\hat{\beta}_2}{\sqrt{ \widehat{\avar}(\hat{\beta}_2)/N }  } \xrightar
 <section id="illustration-extracting-standard-errors" class="slide level4 scrollable">
 <h4>Illustration: Extracting Standard Errors</h4>
 <p>Can get <span class="math inline">\(\widehat{\avar}(\hat{\bbeta})\)</span> from the <code>results</code> object:</p>
-<div id="3fd8f459" class="cell" data-execution_count="3">
+<div id="16fb383b" class="cell" data-execution_count="3">
 <div class="sourceCode cell-code" id="cb4"><pre class="sourceCode numberSource python number-lines code-with-copy"><code class="sourceCode python"><span id="cb4-1"><a></a>(results.nobs)<span class="op">*</span>results.cov_params()</span></code><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></pre></div>
 <div class="cell-output cell-output-display" data-execution_count="3">
 <div>
@@ -1007,7 +1008,7 @@ t = \dfrac{\hat{\beta}_2}{\sqrt{ \widehat{\avar}(\hat{\beta}_2)/N }  } \xrightar
 <section id="illustration-doing-the-test-by-hand" class="slide level4">
 <h4>Illustration: Doing the Test by Hand</h4>
 <p>Compute <span class="math inline">\(t\)</span>-statistic as</p>
-<div id="646b616c" class="cell" data-execution_count="4">
+<div id="63542c85" class="cell" data-execution_count="4">
 <div class="sourceCode cell-code" id="cb5"><pre class="sourceCode numberSource python number-lines code-with-copy"><code class="sourceCode python"><span id="cb5-1"><a></a>t <span class="op">=</span> (results.params.iloc[<span class="dv">1</span>])<span class="op">/</span>np.sqrt(results.cov_params().iloc[<span class="dv">1</span>, <span class="dv">1</span>])</span>
 <span id="cb5-2"><a></a><span class="bu">print</span>(t)</span></code><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></pre></div>
 <div class="cell-output cell-output-stdout">
@@ -1019,7 +1020,7 @@ t = \dfrac{\hat{\beta}_2}{\sqrt{ \widehat{\avar}(\hat{\beta}_2)/N }  } \xrightar
 <li class="fragment">Set <span class="math inline">\(\alpha=0.05\)</span> if want to reject at most 5% under <span class="math inline">\(H_0\)</span> in the limit</li>
 </ul>
 <div class="fragment">
-<div id="ffce0b9d" class="cell" data-execution_count="5">
+<div id="d0bb328c" class="cell" data-execution_count="5">
 <div class="sourceCode cell-code" id="cb7"><pre class="sourceCode numberSource python number-lines code-with-copy"><code class="sourceCode python"><span id="cb7-1"><a></a><span class="im">from</span> scipy.stats <span class="im">import</span> norm</span>
 <span id="cb7-2"><a></a>np.<span class="bu">abs</span>(t) <span class="op">&gt;</span> norm.ppf(<span class="dv">1</span><span class="op">-</span><span class="fl">0.05</span><span class="op">/</span><span class="dv">2</span>)</span></code><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></pre></div>
 <div class="cell-output cell-output-display" data-execution_count="5">
@@ -1035,7 +1036,7 @@ t = \dfrac{\hat{\beta}_2}{\sqrt{ \widehat{\avar}(\hat{\beta}_2)/N }  } \xrightar
 <section id="illustration-using-t_test" class="slide level4">
 <h4>Illustration: Using <code>t_test()</code></h4>
 <p>Can also use</p>
-<div id="c3d0e3c3" class="cell" data-execution_count="6">
+<div id="b0f0974b" class="cell" data-execution_count="6">
 <div class="sourceCode cell-code" id="cb9"><pre class="sourceCode numberSource python number-lines code-with-copy"><code class="sourceCode python"><span id="cb9-1"><a></a>results.t_test(np.array([<span class="dv">0</span>, <span class="dv">1</span>, <span class="dv">0</span>, <span class="dv">0</span>]), use_t<span class="op">=</span><span class="va">False</span>)</span></code><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></pre></div>
 <div class="cell-output cell-output-display" data-execution_count="6">
 <pre><code>&lt;class 'statsmodels.stats.contrast.ContrastResults'&gt;
@@ -1058,7 +1059,7 @@ c0             0.1114      0.002     50.185      0.000       0.107       0.116
 <section id="illustration-t-test-from-the-regression-results" class="slide level4">
 <h4>Illustration: <span class="math inline">\(t\)</span> Test From the Regression Results</h4>
 <p>Regression results also print out results for <span class="math inline">\(t\)</span>-tests of hypotheses <span class="math inline">\(H_0:\beta_k=0\)</span></p>
-<div id="72d69533" class="cell" data-execution_count="7">
+<div id="1876229e" class="cell" data-execution_count="7">
 <div class="cell-output cell-output-stdout">
 <pre><code>                            OLS Regression Results                            
 ==============================================================================
@@ -1066,7 +1067,7 @@ Dep. Variable:               log_wage   R-squared:                       0.226
 Model:                            OLS   Adj. R-squared:                  0.226
 Method:                 Least Squares   F-statistic:                     862.5
 Date:                Mon, 19 May 2025   Prob (F-statistic):               0.00
-Time:                        15:21:55   Log-Likelihood:                -8152.9
+Time:                        17:37:44   Log-Likelihood:                -8152.9
 No. Observations:               10402   AIC:                         1.631e+04
 Df Residuals:                   10398   BIC:                         1.634e+04
 Df Model:                           3                                         
@@ -1311,7 +1312,7 @@ W = N\left(  \bR\hat{\bbeta}-\bq   \right)'\left(\bR\widehat{\avar}(\bbeta)\bR'\
 </section>
 <section id="plot-pdf-of-chi2_k-and-rejection-region-shaded" class="slide level4">
 <h4>Plot: PDF of <span class="math inline">\(\chi^2_k\)</span> and Rejection Region (Shaded)</h4>
-<div id="25c2918d" class="cell" data-execution_count="8">
+<div id="8b842cb1" class="cell" data-execution_count="8">
 <div class="cell-output cell-output-display">
 <div>
 <figure>
@@ -1342,7 +1343,7 @@ W = N\left(  \bR\hat{\bbeta}-\bq   \right)'\left(\bR\widehat{\avar}(\bbeta)\bR'\
 <p>The results class in <code>statsmodels</code> has a <code>wald_test()</code> method</p>
 <div class="fragment">
 <p>First need to define the <span class="math inline">\(\bR\)</span> and <span class="math inline">\(\bq\)</span> matrices:</p>
-<div id="9e22caaf" class="cell" data-execution_count="9">
+<div id="fdfc0aa3" class="cell" data-execution_count="9">
 <div class="sourceCode cell-code" id="cb12"><pre class="sourceCode numberSource python number-lines code-with-copy"><code class="sourceCode python"><span id="cb12-1"><a></a>constraint_matrix <span class="op">=</span> np.array( </span>
 <span id="cb12-2"><a></a>    [[<span class="dv">0</span>, <span class="dv">0</span>, <span class="dv">1</span>, <span class="dv">0</span>],</span>
 <span id="cb12-3"><a></a>     [<span class="dv">0</span>, <span class="dv">0</span>, <span class="dv">0</span>, <span class="dv">1</span>]]</span>
@@ -1364,7 +1365,7 @@ W = N\left(  \bR\hat{\bbeta}-\bq   \right)'\left(\bR\widehat{\avar}(\bbeta)\bR'\
 <section id="effect-of-experience-using-wald_test" class="slide level4">
 <h4>Effect of Experience: Using <code>wald_test()</code></h4>
 <p>Then can supply <span class="math inline">\(\bR\)</span> and <span class="math inline">\(\bq\)</span> to <code>wald_test()</code> as a tuple:</p>
-<div id="36b3fba6" class="cell" data-execution_count="10">
+<div id="de663683" class="cell" data-execution_count="10">
 <div class="sourceCode cell-code" id="cb14"><pre class="sourceCode numberSource python number-lines code-with-copy"><code class="sourceCode python"><span id="cb14-1"><a></a>wald_results <span class="op">=</span> results.wald_test(</span>
 <span id="cb14-2"><a></a>  (constraint_matrix, rhs_vector), </span>
 <span id="cb14-3"><a></a>  use_f<span class="op">=</span><span class="va">False</span>, </span>
@@ -1390,7 +1391,7 @@ H_0: 100\beta_3 + 20\beta_4 = 1.4\quad  \text{ vs } \quad  H_0: 100\beta_3 + 20\
 \]</span></p>
 <div class="fragment">
 <p>Can also do Wald test:</p>
-<div id="f28939cb" class="cell" data-execution_count="11">
+<div id="e6acfe76" class="cell" data-execution_count="11">
 <div class="sourceCode cell-code" id="cb16"><pre class="sourceCode numberSource python number-lines code-with-copy"><code class="sourceCode python"><span id="cb16-1"><a></a>constraint_matrix <span class="op">=</span> np.array( </span>
 <span id="cb16-2"><a></a>    [<span class="dv">0</span>, <span class="dv">0</span>, <span class="dv">100</span>, <span class="dv">20</span>], </span>
 <span id="cb16-3"><a></a>)</span>

--- a/docs/slides/vector/ols-inference.qmd
+++ b/docs/slides/vector/ols-inference.qmd
@@ -4,6 +4,9 @@ subtitle: "Testing Linear Hypotheses. Confidence Intervals"
 author: Vladislav Morozov   
 format:
   revealjs:
+    include-in-header: 
+      text: |
+        <meta name="description" content="Explore testing linear hypotheses and constructing confidence intervals: t-tests, Wald tests, and asymptotic confidence intervals (lecture notes slides)."/> 
     width: 1150
     slide-number: true
     sc-sb-title: true
@@ -24,8 +27,7 @@ title-slide-attributes:
 filters:
   - reveal-header  
 include-in-header: ../../themes/mathjax.html 
-highlight-style: tango
-description: "Explore testing linear hypotheses and constructing confidence intervals: t-tests, Wald tests, and asymptotic confidence intervals (lecture notes slides)."
+highlight-style: tango 
 open-graph:
     description: "Explore testing linear hypotheses and constructing confidence intervals: t-tests, Wald tests, and asymptotic confidence intervals (lecture notes slides)." 
 ---

--- a/docs/slides/vector/ols-limit-distribution.html
+++ b/docs/slides/vector/ols-limit-distribution.html
@@ -538,6 +538,7 @@
     };
 
   </script>
+  <meta name="description" content="Explore the asymptotic distribution of the OLS estimator: definitions, central limit and Slutsky's theorems, asymptotic normality (lecture notes slides).">
 <meta property="og:title" content="Limit Distribution of the OLS Estimator – Advanced Econometrics">
 <meta property="og:description" content="Explore the asymptotic distribution of the OLS estimator: definitions, central limit and Slutsky’s theorems, asymptotic normality (lecture notes slides).">
 <meta property="og:site_name" content="Advanced Econometrics">
@@ -668,7 +669,7 @@ Y_i^\bx = \bx'\bbeta + U_i
 <li class="fragment">Sample: married white women with present spouses</li>
 </ul>
 <p><br></p>
-<div id="a19708d8" class="cell" data-execution_count="1">
+<div id="b8b1f041" class="cell" data-execution_count="1">
 <details class="code-fold">
 <summary>Expand for full data preparation code</summary>
 <div class="sourceCode cell-code" id="cb1"><pre class="sourceCode numberSource python number-lines code-with-copy"><code class="sourceCode python"><span id="cb1-1"><a></a><span class="im">import</span> numpy <span class="im">as</span> np</span>
@@ -707,7 +708,7 @@ Y_i^\bx = \bx'\bbeta + U_i
 <h4>Motivating Empirical Example: Estimation Results</h4>
 <div class="sourceCode" id="cb2" data-code-line-numbers="0-1"><pre class="sourceCode numberSource python number-lines code-with-copy"><code class="sourceCode python"><span id="cb2-1"><a></a>results <span class="op">=</span> OLS(endog, exog).fit(cov_type<span class="op">=</span><span class="st">'HC0'</span>) <span class="co"># Robust covariance matrix estimator</span></span>
 <span id="cb2-2"><a></a><span class="bu">print</span>(results.summary())</span></code><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></pre></div>
-<div id="36f8dc66" class="cell" data-execution_count="2">
+<div id="a51b3721" class="cell" data-execution_count="2">
 <div class="cell-output cell-output-stdout">
 <pre><code>                            OLS Regression Results                            
 ==============================================================================
@@ -715,7 +716,7 @@ Dep. Variable:               log_wage   R-squared:                       0.226
 Model:                            OLS   Adj. R-squared:                  0.226
 Method:                 Least Squares   F-statistic:                     862.5
 Date:                Mon, 19 May 2025   Prob (F-statistic):               0.00
-Time:                        12:55:14   Log-Likelihood:                -8152.9
+Time:                        17:37:49   Log-Likelihood:                -8152.9
 No. Observations:               10402   AIC:                         1.631e+04
 Df Residuals:                   10398   BIC:                         1.634e+04
 Df Model:                           3                                         

--- a/docs/slides/vector/ols-limit-distribution.qmd
+++ b/docs/slides/vector/ols-limit-distribution.qmd
@@ -4,6 +4,9 @@ subtitle: "Key Step Towards Inference"
 author: Vladislav Morozov  
 format:
   revealjs:
+    include-in-header: 
+      text: |
+        <meta name="description" content="Explore the asymptotic distribution of the OLS estimator: definitions, central limit and Slutsky's theorems, asymptotic normality (lecture notes slides)."/> 
     width: 1150
     slide-number: true
     sc-sb-title: true
@@ -24,8 +27,7 @@ title-slide-attributes:
 filters:
   - reveal-header  
 include-in-header: ../../themes/mathjax.html 
-highlight-style: tango
-description: "Explore the asymptotic distribution of the OLS estimator: definitions, central limit and Slutsky's theorems, asymptotic normality (lecture notes slides)."
+highlight-style: tango 
 open-graph:
     description: "Explore the asymptotic distribution of the OLS estimator: definitions, central limit and Slutsky's theorems, asymptotic normality (lecture notes slides)." 
 ---

--- a/docs/slides/vector/vector-ols.qmd
+++ b/docs/slides/vector/vector-ols.qmd
@@ -4,6 +4,9 @@ subtitle: "A Concise and General Approach"
 author: Vladislav Morozov  
 format:
   revealjs:
+    include-in-header: 
+      text: |
+        <meta name="description" content="Explore vector-matrix form of linear regression - scalar, vector, and matrix representations and OLS estimator derivation (lecture notes slides)."/> 
     width: 1150
     slide-number: true
     sc-sb-title: true
@@ -25,8 +28,7 @@ filters:
   - reveal-header 
 embed-resources: true
 include-in-header: ../../themes/mathjax.html 
-highlight-style: tango
-description: "Explore vector-matrix form of linear regression: scalar, vector, and matrix representations and OLS estimator derivation (lecture notes slides)."
+highlight-style: tango 
 open-graph:
     description: "Explore vector-matrix form of linear regression: scalar, vector, and matrix representations and OLS estimator derivation (lecture notes slides)." 
 ---

--- a/src/slides/organizational/intro.qmd
+++ b/src/slides/organizational/intro.qmd
@@ -4,6 +4,9 @@ subtitle: "Advanced Econometrics"
 author: Vladislav Morozov  
 format:
   revealjs:
+    include-in-header: 
+      text:
+        <meta name="description" content="Course introduction for advanced econometrics (econometrics 2), covering course overview, logistics, and reference books (lecture notes slides)."/> 
     width: 1150
     slide-number: true
     sc-sb-title: true
@@ -26,7 +29,6 @@ filters:
 embed-resources: true
 include-in-header: ../../themes/mathjax.html 
 highlight-style: tango
-description: "Course introduction for advanced econometrics (econometrics 2), covering course overview, logistics, and reference books (lecture notes slides)."
 open-graph:
     description: "Course introduction for advanced econometrics (econometrics 2), covering course overview, logistics, and reference books (lecture notes slides)." 
 ---

--- a/src/slides/organizational/intro.qmd
+++ b/src/slides/organizational/intro.qmd
@@ -5,7 +5,7 @@ author: Vladislav Morozov
 format:
   revealjs:
     include-in-header: 
-      text:
+      text: |
         <meta name="description" content="Course introduction for advanced econometrics (econometrics 2), covering course overview, logistics, and reference books (lecture notes slides)."/> 
     width: 1150
     slide-number: true

--- a/src/slides/vector/identification-inference.qmd
+++ b/src/slides/vector/identification-inference.qmd
@@ -4,6 +4,9 @@ subtitle: "The Three Parts of Statistics"
 author: Vladislav Morozov  
 format:
   revealjs:
+    include-in-header: 
+      text: |
+        <meta name="description" content="Explore the basics of identification, estimation, and inference: definitions, parametric models, and linear model identification (lecture notes slides)."/> 
     width: 1150
     slide-number: true
     sc-sb-title: true

--- a/src/slides/vector/ols-consistency.qmd
+++ b/src/slides/vector/ols-consistency.qmd
@@ -4,6 +4,9 @@ subtitle: "Convergence as Sample Size Grows"
 author: Vladislav Morozov  
 format:
   revealjs:
+    include-in-header: 
+      text: |
+        <meta name="description" content="Learn about the consistency of the OLS estimator: definitions, intuition, proof of consistency in model-free and causal frameworks (lecture notes slides)."/> 
     width: 1150
     slide-number: true
     sc-sb-title: true
@@ -24,8 +27,7 @@ title-slide-attributes:
 filters:
   - reveal-header  
 include-in-header: ../../themes/mathjax.html 
-highlight-style: tango
-description: "Learn about the consistency of the OLS estimator: definitions, intuition, proof of consistency in model-free and causal frameworks (lecture notes slides)."
+highlight-style: tango 
 open-graph:
     description: "Learn about the consistency of the OLS estimator: definitions, intuition, proof of consistency in model-free and causal frameworks (lecture notes slides)." 
 ---

--- a/src/slides/vector/ols-delta-method.qmd
+++ b/src/slides/vector/ols-delta-method.qmd
@@ -4,6 +4,9 @@ subtitle: "Handling Nonlinearities with the Delta Method"
 author: Vladislav Morozov   
 format:
   revealjs:
+    include-in-header: 
+      text: |
+        <meta name="description" content="Explore the delta method for nonlinear functions of parameters: asymptotic distribution, confidence intervals, hypothesis testing (lecture notes slides)."/> 
     width: 1150
     slide-number: true
     sc-sb-title: true
@@ -24,8 +27,7 @@ title-slide-attributes:
 filters:
   - reveal-header  
 include-in-header: ../../themes/mathjax.html 
-highlight-style: tango
-description: "Explore the delta method for nonlinear functions of parameters: asymptotic distribution, confidence intervals, hypothesis testing (lecture notes slides)."
+highlight-style: tango 
 open-graph:
     description: "Explore the delta method for nonlinear functions of parameters: asymptotic distribution, confidence intervals, hypothesis testing (lecture notes slides)." 
 ---

--- a/src/slides/vector/ols-inference.qmd
+++ b/src/slides/vector/ols-inference.qmd
@@ -4,6 +4,9 @@ subtitle: "Testing Linear Hypotheses. Confidence Intervals"
 author: Vladislav Morozov   
 format:
   revealjs:
+    include-in-header: 
+      text: |
+        <meta name="description" content="Explore testing linear hypotheses and constructing confidence intervals: t-tests, Wald tests, and asymptotic confidence intervals (lecture notes slides)."/> 
     width: 1150
     slide-number: true
     sc-sb-title: true
@@ -24,8 +27,7 @@ title-slide-attributes:
 filters:
   - reveal-header  
 include-in-header: ../../themes/mathjax.html 
-highlight-style: tango
-description: "Explore testing linear hypotheses and constructing confidence intervals: t-tests, Wald tests, and asymptotic confidence intervals (lecture notes slides)."
+highlight-style: tango 
 open-graph:
     description: "Explore testing linear hypotheses and constructing confidence intervals: t-tests, Wald tests, and asymptotic confidence intervals (lecture notes slides)." 
 ---

--- a/src/slides/vector/ols-limit-distribution.qmd
+++ b/src/slides/vector/ols-limit-distribution.qmd
@@ -4,6 +4,9 @@ subtitle: "Key Step Towards Inference"
 author: Vladislav Morozov  
 format:
   revealjs:
+    include-in-header: 
+      text: |
+        <meta name="description" content="Explore the asymptotic distribution of the OLS estimator: definitions, central limit and Slutsky's theorems, asymptotic normality (lecture notes slides)."/> 
     width: 1150
     slide-number: true
     sc-sb-title: true
@@ -24,8 +27,7 @@ title-slide-attributes:
 filters:
   - reveal-header  
 include-in-header: ../../themes/mathjax.html 
-highlight-style: tango
-description: "Explore the asymptotic distribution of the OLS estimator: definitions, central limit and Slutsky's theorems, asymptotic normality (lecture notes slides)."
+highlight-style: tango 
 open-graph:
     description: "Explore the asymptotic distribution of the OLS estimator: definitions, central limit and Slutsky's theorems, asymptotic normality (lecture notes slides)." 
 ---

--- a/src/slides/vector/vector-ols.qmd
+++ b/src/slides/vector/vector-ols.qmd
@@ -4,6 +4,9 @@ subtitle: "A Concise and General Approach"
 author: Vladislav Morozov  
 format:
   revealjs:
+    include-in-header: 
+      text: |
+        <meta name="description" content="Explore vector-matrix form of linear regression - scalar, vector, and matrix representations and OLS estimator derivation (lecture notes slides)."/> 
     width: 1150
     slide-number: true
     sc-sb-title: true
@@ -25,8 +28,7 @@ filters:
   - reveal-header 
 embed-resources: true
 include-in-header: ../../themes/mathjax.html 
-highlight-style: tango
-description: "Explore vector-matrix form of linear regression: scalar, vector, and matrix representations and OLS estimator derivation (lecture notes slides)."
+highlight-style: tango 
 open-graph:
     description: "Explore vector-matrix form of linear regression: scalar, vector, and matrix representations and OLS estimator derivation (lecture notes slides)." 
 ---


### PR DESCRIPTION
## Description

As it turns out, meta descriptions should be handled differently in RevealJS slides relative to normal pages. This PR inserts correct meta descriptions in all current slides.

## Pages Affected

All the lecture slides in the following blocks:

- Intro
- Asymptotic theory for OLS
- Asymptotic inference