### PR TITLE
Fix Minor Typos in DiD Lecture

### DIFF
--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -22,7 +22,7 @@
   </url>
   <url>
     <loc>https://vladislav-morozov.github.io/econometrics-2/slides/panel/did.html</loc>
-    <lastmod>2025-06-02T17:40:06.057Z</lastmod>
+    <lastmod>2025-06-06T06:18:53.314Z</lastmod>
   </url>
   <url>
     <loc>https://vladislav-morozov.github.io/econometrics-2/slides/organizational/intro.html</loc>
@@ -50,7 +50,7 @@
   </url>
   <url>
     <loc>https://vladislav-morozov.github.io/econometrics-2/slides/panel/event-studies.html</loc>
-    <lastmod>2025-06-03T19:36:38.644Z</lastmod>
+    <lastmod>2025-06-04T08:28:12.487Z</lastmod>
   </url>
   <url>
     <loc>https://vladislav-morozov.github.io/econometrics-2/slides/panel/mean-group.html</loc>

--- a/docs/slides/panel/did.html
+++ b/docs/slides/panel/did.html
@@ -543,42 +543,23 @@
 
   </script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js" integrity="sha512-c3Nl8+7g4LMSTdrm621y7kf9v3SDPnhxLNhcjFJbKECVnmZHTdo+IRO05sNLTH/D3vA6u1X32ehoLC7WFVdheg==" crossorigin="anonymous"></script>
-
   
-
   <script type="application/javascript">define('jquery', [],function() {return window.jQuery;})</script>
-
   <script type="text/javascript">
-
   window.PlotlyConfig = {MathJaxConfig: 'local'};
-
   if (window.MathJax && window.MathJax.Hub && window.MathJax.Hub.Config) {window.MathJax.Hub.Config({SVG: {font: "STIX-Web"}});}
-
   if (typeof require !== 'undefined') {
-
   require.undef("plotly");
-
   requirejs.config({
-
       paths: {
-
           'plotly': ['https://cdn.plot.ly/plotly-2.35.2.min']
-
       }
-
   });
-
   require(['plotly'], function(Plotly) {
-
       window._Plotly = Plotly;
-
   });
-
   }
-
   </script>
-
-  
 
   <meta name="description" content="Difference-in-differences estimation: parallel trends, ATT identification, regression characterization, application to minimum wage (lecture notes slides).">
 <meta property="og:title" content="Difference-in-Differences – Advanced Econometrics">
@@ -1002,12 +983,12 @@ CATT(\bx) = \E[Y_{i2}^0 - Y_{i1}^0 |T, \bX_{i}=\bx]
 <h4>Adding Covariates II: Assuming Linearity</h4>
 <p>Often see <span class="highlight">linearity assumptions</span> on the causal model in the form: <span class="math display">\[
 \begin{aligned}
-Y_{it}^d = Y_{it}^0 + d(Y_{i2}^1- Y_{i2}^0) + \bX_{it}'\bbeta_i
+Y_{it}^d = Y_{it}^0 + d(Y_{it}^1- Y_{it}^0) + \bX_{it}'\bbeta_i
 \end{aligned}
 \]</span></p>
 <div class="fragment">
 <p>Can estimate ATT consistently from TWFE regression <span class="math display">\[
-Y_{i2}-Y_{i1} = \gamma + \delta D_{it} + (\bX_{i2}-\bX_{i1})'\bbeta + u_{it},
+Y_{i2}-Y_{i1} = \gamma + \delta D_{it} + (\bX_{i2}-\bX_{i1})'\bbeta + U_{it},
 \]</span> if <span class="math inline">\(\bbeta\)</span> appropriately defined (think of OLS estimator under heterogeneous coefficient causal model)</p>
 </div>
 </section>
@@ -1017,10 +998,10 @@ Y_{i2}-Y_{i1} = \gamma + \delta D_{it} + (\bX_{i2}-\bX_{i1})'\bbeta + u_{it},
 <ul>
 <li class="fragment"><span class="math inline">\(T\geq 2\)</span></li>
 <li class="fragment">Two groups: never treated (<span class="math inline">\(U\)</span>) and treated, treatment starts between <span class="math inline">\(t_0-1\)</span> and <span class="math inline">\(t_0\)</span></li>
-<li class="fragment">Treatment indicators <span class="math inline">\(D_{it\tau}\)</span>, <span class="math inline">\(t, \tau=1,\dots, T\)</span>:
+<li class="fragment">Treatment indicators <span class="math inline">\(D_{it, \tau}\)</span>, <span class="math inline">\(t, \tau=1,\dots, T\)</span>:
 <ul>
-<li class="fragment">Untreated units have <span class="math inline">\(D_{it\tau}=0\)</span> for all <span class="math inline">\(t, \tau\)</span></li>
-<li class="fragment">Treated units <span class="math inline">\(D_{it\tau}=1\)</span> if and only if <span class="math inline">\(t=\tau\)</span> and <span class="math inline">\(t\geq t_0\)</span></li>
+<li class="fragment">Untreated units have <span class="math inline">\(D_{it, \tau}=0\)</span> for all <span class="math inline">\(t, \tau\)</span></li>
+<li class="fragment">Treated units <span class="math inline">\(D_{it, \tau}=1\)</span> if and only if <span class="math inline">\(t=\tau\)</span> and <span class="math inline">\(t\geq t_0\)</span></li>
 </ul></li>
 </ul>
 </section>
@@ -1028,7 +1009,7 @@ Y_{i2}-Y_{i1} = \gamma + \delta D_{it} + (\bX_{i2}-\bX_{i1})'\bbeta + u_{it},
 <h4>Adding More Periods: TWFE</h4>
 <p>Multi-period specification: <span class="math display">\[ \small
 \begin{aligned}
-Y_{it} &amp;  = \alpha_i + \gamma_t + \sum_{\tau=t_0}^T \delta_\tau D_{it\tau}  + U_{it},\\
+Y_{it} &amp;  = \alpha_i + \gamma_t + \sum_{\tau=t_0}^T \delta_\tau D_{it, \tau}  + U_{it},\\
 \alpha_i &amp; = Y_{i1}^0, \\
 \gamma_t &amp; = \E[Y_{it}^0- Y_{i1}^0|T],\\
 \delta_t &amp; = \E[Y_{it}^1- Y_{it}^0|T]
@@ -1090,7 +1071,7 @@ Y_{it} &amp;  = \alpha_i + \gamma_t + \sum_{\tau=t_0}^T \delta_\tau D_{it\tau}  
 </section>
 <section id="loading-and-looking-at-the-data" class="slide level4">
 <h4>Loading and Looking at the Data</h4>
-<div id="52b91b58" class="cell" data-execution_count="2">
+<div id="3471fe90" class="cell" data-execution_count="2">
 <details class="code-fold">
 <summary>Loading and processing the data</summary>
 <div class="sourceCode cell-code" id="cb1"><pre class="sourceCode numberSource python number-lines code-with-copy"><code class="sourceCode python"><span id="cb1-1"><a></a>ck_data <span class="op">=</span> pd.read_csv(<span class="st">"data/card-krueger-1994.csv"</span>)</span>
@@ -1240,7 +1221,7 @@ Y_{it} &amp;  = \alpha_i + \gamma_t + \sum_{\tau=t_0}^T \delta_\tau D_{it\tau}  
 <section id="tabulating-averages" class="slide level4">
 <h4>Tabulating Averages</h4>
 <p>The key components of difference-in-differences are the (state, year)-specific average outcomes:</p>
-<div id="ce1c937b" class="cell" data-execution_count="3">
+<div id="61b7f51e" class="cell" data-execution_count="3">
 <details class="code-fold">
 <summary>Computing (state, year)-averages</summary>
 <div class="sourceCode cell-code" id="cb2"><pre class="sourceCode numberSource python number-lines code-with-copy"><code class="sourceCode python"><span id="cb2-1"><a></a>emp_means <span class="op">=</span> ck_data.groupby(by<span class="op">=</span>[<span class="st">"state_name"</span>, <span class="st">"time_name"</span>])[<span class="st">"emp_ft"</span>].mean()</span>
@@ -1259,7 +1240,7 @@ Name: emp_ft, dtype: float64</code></pre>
 <section id="applying-did" class="slide level4">
 <h4>Applying DiD</h4>
 <p>It is easy to compute averages now. Recall that <code>NJ</code> is the treated group. Applying DiD:</p>
-<div id="87802411" class="cell" data-execution_count="4">
+<div id="ef8aa2a9" class="cell" data-execution_count="4">
 <details class="code-fold">
 <summary>Applying DiD manually</summary>
 <div class="sourceCode cell-code" id="cb4"><pre class="sourceCode numberSource python number-lines code-with-copy"><code class="sourceCode python"><span id="cb4-1"><a></a>( </span>
@@ -1275,11 +1256,11 @@ Name: emp_ft, dtype: float64</code></pre>
 </section>
 <section id="visualizing-1992-employment-levels" class="slide level4">
 <h4>Visualizing 1992 Employment Levels</h4>
-<div id="dbcdf054" class="cell" data-execution_count="5">
+<div id="d5546ae4" class="cell" data-execution_count="5">
 <div class="cell-output cell-output-display">
-<div>                            <div id="3e60cb46-ff64-4acb-9dec-4294d609c856" class="plotly-graph-div" style="height:550px; width:1150px;"></div>            <script type="text/javascript">                require(["plotly"], function(Plotly) {                    window.PLOTLYENV=window.PLOTLYENV || {};                                    if (document.getElementById("3e60cb46-ff64-4acb-9dec-4294d609c856")) {                    Plotly.newPlot(                        "3e60cb46-ff64-4acb-9dec-4294d609c856",                        [{"colorscale":[[0.0,"rgb(247,251,255)"],[0.125,"rgb(222,235,247)"],[0.25,"rgb(198,219,239)"],[0.375,"rgb(158,202,225)"],[0.5,"rgb(107,174,214)"],[0.625,"rgb(66,146,198)"],[0.75,"rgb(33,113,181)"],[0.875,"rgb(8,81,156)"],[1.0,"rgb(8,48,107)"]],"hovertemplate":"\u003cb\u003e%{location}\u003c\u002fb\u003e\u003cbr\u003eFT-equivalent workers: %{z:.2f}","locationmode":"USA-states","locations":["NJ","PA"],"name":"Actual","showscale":false,"z":[20.92556634304207,21.14],"zmax":22,"zmin":18,"type":"choropleth","geo":"geo"},{"colorbar":{"len":0.8,"thickness":15,"tickvals":[18,22],"title":{"font":{"color":"black","size":12},"side":"right","text":"Number of Workers"},"x":1,"y":0.5},"colorscale":[[0.0,"rgb(247,251,255)"],[0.125,"rgb(222,235,247)"],[0.25,"rgb(198,219,239)"],[0.375,"rgb(158,202,225)"],[0.5,"rgb(107,174,214)"],[0.625,"rgb(66,146,198)"],[0.75,"rgb(33,113,181)"],[0.875,"rgb(8,81,156)"],[1.0,"rgb(8,48,107)"]],"hovertemplate":"\u003cb\u003e%{location}\u003c\u002fb\u003e\u003cbr\u003eFT-equivalent workers: %{z:.2f}","locationmode":"USA-states","locations":["NJ","PA"],"name":"Counterfactual","z":[18.175728155339804,21.14],"zmax":22,"zmin":18,"type":"choropleth","geo":"geo2"}],                        {"template":{"data":{"histogram2dcontour":[{"type":"histogram2dcontour","colorbar":{"outlinewidth":0,"ticks":""},"colorscale":[[0.0,"#0d0887"],[0.1111111111111111,"#46039f"],[0.2222222222222222,"#7201a8"],[0.3333333333333333,"#9c179e"],[0.4444444444444444,"#bd3786"],[0.5555555555555556,"#d8576b"],[0.6666666666666666,"#ed7953"],[0.7777777777777778,"#fb9f3a"],[0.8888888888888888,"#fdca26"],[1.0,"#f0f921"]]}],"choropleth":[{"type":"choropleth","colorbar":{"outlinewidth":0,"ticks":""}}],"histogram2d":[{"type":"histogram2d","colorbar":{"outlinewidth":0,"ticks":""},"colorscale":[[0.0,"#0d0887"],[0.1111111111111111,"#46039f"],[0.2222222222222222,"#7201a8"],[0.3333333333333333,"#9c179e"],[0.4444444444444444,"#bd3786"],[0.5555555555555556,"#d8576b"],[0.6666666666666666,"#ed7953"],[0.7777777777777778,"#fb9f3a"],[0.8888888888888888,"#fdca26"],[1.0,"#f0f921"]]}],"heatmap":[{"type":"heatmap","colorbar":{"outlinewidth":0,"ticks":""},"colorscale":[[0.0,"#0d0887"],[0.1111111111111111,"#46039f"],[0.2222222222222222,"#7201a8"],[0.3333333333333333,"#9c179e"],[0.4444444444444444,"#bd3786"],[0.5555555555555556,"#d8576b"],[0.6666666666666666,"#ed7953"],[0.7777777777777778,"#fb9f3a"],[0.8888888888888888,"#fdca26"],[1.0,"#f0f921"]]}],"heatmapgl":[{"type":"heatmapgl","colorbar":{"outlinewidth":0,"ticks":""},"colorscale":[[0.0,"#0d0887"],[0.1111111111111111,"#46039f"],[0.2222222222222222,"#7201a8"],[0.3333333333333333,"#9c179e"],[0.4444444444444444,"#bd3786"],[0.5555555555555556,"#d8576b"],[0.6666666666666666,"#ed7953"],[0.7777777777777778,"#fb9f3a"],[0.8888888888888888,"#fdca26"],[1.0,"#f0f921"]]}],"contourcarpet":[{"type":"contourcarpet","colorbar":{"outlinewidth":0,"ticks":""}}],"contour":[{"type":"contour","colorbar":{"outlinewidth":0,"ticks":""},"colorscale":[[0.0,"#0d0887"],[0.1111111111111111,"#46039f"],[0.2222222222222222,"#7201a8"],[0.3333333333333333,"#9c179e"],[0.4444444444444444,"#bd3786"],[0.5555555555555556,"#d8576b"],[0.6666666666666666,"#ed7953"],[0.7777777777777778,"#fb9f3a"],[0.8888888888888888,"#fdca26"],[1.0,"#f0f921"]]}],"surface":[{"type":"surface","colorbar":{"outlinewidth":0,"ticks":""},"colorscale":[[0.0,"#0d0887"],[0.1111111111111111,"#46039f"],[0.2222222222222222,"#7201a8"],[0.3333333333333333,"#9c179e"],[0.4444444444444444,"#bd3786"],[0.5555555555555556,"#d8576b"],[0.6666666666666666,"#ed7953"],[0.7777777777777778,"#fb9f3a"],[0.8888888888888888,"#fdca26"],[1.0,"#f0f921"]]}],"mesh3d":[{"type":"mesh3d","colorbar":{"outlinewidth":0,"ticks":""}}],"scatter":[{"fillpattern":{"fillmode":"overlay","size":10,"solidity":0.2},"type":"scatter"}],"parcoords":[{"type":"parcoords","line":{"colorbar":{"outlinewidth":0,"ticks":""}}}],"scatterpolargl":[{"type":"scatterpolargl","marker":{"colorbar":{"outlinewidth":0,"ticks":""}}}],"bar":[{"error_x":{"color":"#2a3f5f"},"error_y":{"color":"#2a3f5f"},"marker":{"line":{"color":"#E5ECF6","width":0.5},"pattern":{"fillmode":"overlay","size":10,"solidity":0.2}},"type":"bar"}],"scattergeo":[{"type":"scattergeo","marker":{"colorbar":{"outlinewidth":0,"ticks":""}}}],"scatterpolar":[{"type":"scatterpolar","marker":{"colorbar":{"outlinewidth":0,"ticks":""}}}],"histogram":[{"marker":{"pattern":{"fillmode":"overlay","size":10,"solidity":0.2}},"type":"histogram"}],"scattergl":[{"type":"scattergl","marker":{"colorbar":{"outlinewidth":0,"ticks":""}}}],"scatter3d":[{"type":"scatter3d","line":{"colorbar":{"outlinewidth":0,"ticks":""}},"marker":{"colorbar":{"outlinewidth":0,"ticks":""}}}],"scattermapbox":[{"type":"scattermapbox","marker":{"colorbar":{"outlinewidth":0,"ticks":""}}}],"scatterternary":[{"type":"scatterternary","marker":{"colorbar":{"outlinewidth":0,"ticks":""}}}],"scattercarpet":[{"type":"scattercarpet","marker":{"colorbar":{"outlinewidth":0,"ticks":""}}}],"carpet":[{"aaxis":{"endlinecolor":"#2a3f5f","gridcolor":"white","linecolor":"white","minorgridcolor":"white","startlinecolor":"#2a3f5f"},"baxis":{"endlinecolor":"#2a3f5f","gridcolor":"white","linecolor":"white","minorgridcolor":"white","startlinecolor":"#2a3f5f"},"type":"carpet"}],"table":[{"cells":{"fill":{"color":"#EBF0F8"},"line":{"color":"white"}},"header":{"fill":{"color":"#C8D4E3"},"line":{"color":"white"}},"type":"table"}],"barpolar":[{"marker":{"line":{"color":"#E5ECF6","width":0.5},"pattern":{"fillmode":"overlay","size":10,"solidity":0.2}},"type":"barpolar"}],"pie":[{"automargin":true,"type":"pie"}]},"layout":{"autotypenumbers":"strict","colorway":["#636efa","#EF553B","#00cc96","#ab63fa","#FFA15A","#19d3f3","#FF6692","#B6E880","#FF97FF","#FECB52"],"font":{"color":"#2a3f5f"},"hovermode":"closest","hoverlabel":{"align":"left"},"paper_bgcolor":"white","plot_bgcolor":"#E5ECF6","polar":{"bgcolor":"#E5ECF6","angularaxis":{"gridcolor":"white","linecolor":"white","ticks":""},"radialaxis":{"gridcolor":"white","linecolor":"white","ticks":""}},"ternary":{"bgcolor":"#E5ECF6","aaxis":{"gridcolor":"white","linecolor":"white","ticks":""},"baxis":{"gridcolor":"white","linecolor":"white","ticks":""},"caxis":{"gridcolor":"white","linecolor":"white","ticks":""}},"coloraxis":{"colorbar":{"outlinewidth":0,"ticks":""}},"colorscale":{"sequential":[[0.0,"#0d0887"],[0.1111111111111111,"#46039f"],[0.2222222222222222,"#7201a8"],[0.3333333333333333,"#9c179e"],[0.4444444444444444,"#bd3786"],[0.5555555555555556,"#d8576b"],[0.6666666666666666,"#ed7953"],[0.7777777777777778,"#fb9f3a"],[0.8888888888888888,"#fdca26"],[1.0,"#f0f921"]],"sequentialminus":[[0.0,"#0d0887"],[0.1111111111111111,"#46039f"],[0.2222222222222222,"#7201a8"],[0.3333333333333333,"#9c179e"],[0.4444444444444444,"#bd3786"],[0.5555555555555556,"#d8576b"],[0.6666666666666666,"#ed7953"],[0.7777777777777778,"#fb9f3a"],[0.8888888888888888,"#fdca26"],[1.0,"#f0f921"]],"diverging":[[0,"#8e0152"],[0.1,"#c51b7d"],[0.2,"#de77ae"],[0.3,"#f1b6da"],[0.4,"#fde0ef"],[0.5,"#f7f7f7"],[0.6,"#e6f5d0"],[0.7,"#b8e186"],[0.8,"#7fbc41"],[0.9,"#4d9221"],[1,"#276419"]]},"xaxis":{"gridcolor":"white","linecolor":"white","ticks":"","title":{"standoff":15},"zerolinecolor":"white","automargin":true,"zerolinewidth":2},"yaxis":{"gridcolor":"white","linecolor":"white","ticks":"","title":{"standoff":15},"zerolinecolor":"white","automargin":true,"zerolinewidth":2},"scene":{"xaxis":{"backgroundcolor":"#E5ECF6","gridcolor":"white","linecolor":"white","showbackground":true,"ticks":"","zerolinecolor":"white","gridwidth":2},"yaxis":{"backgroundcolor":"#E5ECF6","gridcolor":"white","linecolor":"white","showbackground":true,"ticks":"","zerolinecolor":"white","gridwidth":2},"zaxis":{"backgroundcolor":"#E5ECF6","gridcolor":"white","linecolor":"white","showbackground":true,"ticks":"","zerolinecolor":"white","gridwidth":2}},"shapedefaults":{"line":{"color":"#2a3f5f"}},"annotationdefaults":{"arrowcolor":"#2a3f5f","arrowhead":0,"arrowwidth":1},"geo":{"bgcolor":"white","landcolor":"#E5ECF6","subunitcolor":"white","showland":true,"showlakes":true,"lakecolor":"white"},"title":{"x":0.05},"mapbox":{"style":"light"},"margin":{"b":0,"l":0,"r":0,"t":30}}},"geo":{"domain":{"x":[0,0.48],"y":[0.0,1.0]},"projection":{"type":"mercator","scale":40},"center":{"lat":39.9,"lon":-75.1},"visible":false,"bgcolor":"rgb(201, 201, 201)","landcolor":"rgb(201, 201, 201)","lakecolor":"rgb(201, 201, 201)","showocean":true,"oceancolor":"rgb(136, 136, 136)"},"geo2":{"domain":{"x":[0.52,1],"y":[0.0,1.0]},"projection":{"type":"mercator","scale":40},"center":{"lat":39.9,"lon":-75.1},"visible":false,"bgcolor":"rgb(201, 201, 201)","landcolor":"rgb(201, 201, 201)","lakecolor":"rgb(201, 201, 201)","showocean":true,"oceancolor":"rgb(136, 136, 136)"},"annotations":[{"font":{"size":16},"showarrow":false,"text":"Actual employment","x":0.225,"xanchor":"center","xref":"paper","y":1.0,"yanchor":"bottom","yref":"paper"},{"font":{"size":16},"showarrow":false,"text":"Employment without minimum wage changes","x":0.775,"xanchor":"center","xref":"paper","y":1.0,"yanchor":"bottom","yref":"paper"}],"font":{"family":"Arial","color":"black"},"title":{"font":{"color":"black","size":20},"text":"\u003cb\u003eRealized vs. Counterfactual Employment\u003c\u002fb\u003e","x":0.03,"xanchor":"left","y":0.97,"yanchor":"top"},"margin":{"l":20,"r":20,"t":60,"b":20},"width":1150,"height":550,"plot_bgcolor":"whitesmoke","paper_bgcolor":"whitesmoke"},                        {"responsive": true}                    ).then(function(){
+<div>                            <div id="4555fc04-0498-4221-bbd4-25270f722487" class="plotly-graph-div" style="height:550px; width:1150px;"></div>            <script type="text/javascript">                require(["plotly"], function(Plotly) {                    window.PLOTLYENV=window.PLOTLYENV || {};                                    if (document.getElementById("4555fc04-0498-4221-bbd4-25270f722487")) {                    Plotly.newPlot(                        "4555fc04-0498-4221-bbd4-25270f722487",                        [{"colorscale":[[0.0,"rgb(247,251,255)"],[0.125,"rgb(222,235,247)"],[0.25,"rgb(198,219,239)"],[0.375,"rgb(158,202,225)"],[0.5,"rgb(107,174,214)"],[0.625,"rgb(66,146,198)"],[0.75,"rgb(33,113,181)"],[0.875,"rgb(8,81,156)"],[1.0,"rgb(8,48,107)"]],"hovertemplate":"\u003cb\u003e%{location}\u003c\u002fb\u003e\u003cbr\u003eFT-equivalent workers: %{z:.2f}","locationmode":"USA-states","locations":["NJ","PA"],"name":"Actual","showscale":false,"z":[20.92556634304207,21.14],"zmax":22,"zmin":18,"type":"choropleth","geo":"geo"},{"colorbar":{"len":0.8,"thickness":15,"tickvals":[18,22],"title":{"font":{"color":"black","size":12},"side":"right","text":"Number of Workers"},"x":1,"y":0.5},"colorscale":[[0.0,"rgb(247,251,255)"],[0.125,"rgb(222,235,247)"],[0.25,"rgb(198,219,239)"],[0.375,"rgb(158,202,225)"],[0.5,"rgb(107,174,214)"],[0.625,"rgb(66,146,198)"],[0.75,"rgb(33,113,181)"],[0.875,"rgb(8,81,156)"],[1.0,"rgb(8,48,107)"]],"hovertemplate":"\u003cb\u003e%{location}\u003c\u002fb\u003e\u003cbr\u003eFT-equivalent workers: %{z:.2f}","locationmode":"USA-states","locations":["NJ","PA"],"name":"Counterfactual","z":[18.175728155339804,21.14],"zmax":22,"zmin":18,"type":"choropleth","geo":"geo2"}],                        {"template":{"data":{"histogram2dcontour":[{"type":"histogram2dcontour","colorbar":{"outlinewidth":0,"ticks":""},"colorscale":[[0.0,"#0d0887"],[0.1111111111111111,"#46039f"],[0.2222222222222222,"#7201a8"],[0.3333333333333333,"#9c179e"],[0.4444444444444444,"#bd3786"],[0.5555555555555556,"#d8576b"],[0.6666666666666666,"#ed7953"],[0.7777777777777778,"#fb9f3a"],[0.8888888888888888,"#fdca26"],[1.0,"#f0f921"]]}],"choropleth":[{"type":"choropleth","colorbar":{"outlinewidth":0,"ticks":""}}],"histogram2d":[{"type":"histogram2d","colorbar":{"outlinewidth":0,"ticks":""},"colorscale":[[0.0,"#0d0887"],[0.1111111111111111,"#46039f"],[0.2222222222222222,"#7201a8"],[0.3333333333333333,"#9c179e"],[0.4444444444444444,"#bd3786"],[0.5555555555555556,"#d8576b"],[0.6666666666666666,"#ed7953"],[0.7777777777777778,"#fb9f3a"],[0.8888888888888888,"#fdca26"],[1.0,"#f0f921"]]}],"heatmap":[{"type":"heatmap","colorbar":{"outlinewidth":0,"ticks":""},"colorscale":[[0.0,"#0d0887"],[0.1111111111111111,"#46039f"],[0.2222222222222222,"#7201a8"],[0.3333333333333333,"#9c179e"],[0.4444444444444444,"#bd3786"],[0.5555555555555556,"#d8576b"],[0.6666666666666666,"#ed7953"],[0.7777777777777778,"#fb9f3a"],[0.8888888888888888,"#fdca26"],[1.0,"#f0f921"]]}],"heatmapgl":[{"type":"heatmapgl","colorbar":{"outlinewidth":0,"ticks":""},"colorscale":[[0.0,"#0d0887"],[0.1111111111111111,"#46039f"],[0.2222222222222222,"#7201a8"],[0.3333333333333333,"#9c179e"],[0.4444444444444444,"#bd3786"],[0.5555555555555556,"#d8576b"],[0.6666666666666666,"#ed7953"],[0.7777777777777778,"#fb9f3a"],[0.8888888888888888,"#fdca26"],[1.0,"#f0f921"]]}],"contourcarpet":[{"type":"contourcarpet","colorbar":{"outlinewidth":0,"ticks":""}}],"contour":[{"type":"contour","colorbar":{"outlinewidth":0,"ticks":""},"colorscale":[[0.0,"#0d0887"],[0.1111111111111111,"#46039f"],[0.2222222222222222,"#7201a8"],[0.3333333333333333,"#9c179e"],[0.4444444444444444,"#bd3786"],[0.5555555555555556,"#d8576b"],[0.6666666666666666,"#ed7953"],[0.7777777777777778,"#fb9f3a"],[0.8888888888888888,"#fdca26"],[1.0,"#f0f921"]]}],"surface":[{"type":"surface","colorbar":{"outlinewidth":0,"ticks":""},"colorscale":[[0.0,"#0d0887"],[0.1111111111111111,"#46039f"],[0.2222222222222222,"#7201a8"],[0.3333333333333333,"#9c179e"],[0.4444444444444444,"#bd3786"],[0.5555555555555556,"#d8576b"],[0.6666666666666666,"#ed7953"],[0.7777777777777778,"#fb9f3a"],[0.8888888888888888,"#fdca26"],[1.0,"#f0f921"]]}],"mesh3d":[{"type":"mesh3d","colorbar":{"outlinewidth":0,"ticks":""}}],"scatter":[{"fillpattern":{"fillmode":"overlay","size":10,"solidity":0.2},"type":"scatter"}],"parcoords":[{"type":"parcoords","line":{"colorbar":{"outlinewidth":0,"ticks":""}}}],"scatterpolargl":[{"type":"scatterpolargl","marker":{"colorbar":{"outlinewidth":0,"ticks":""}}}],"bar":[{"error_x":{"color":"#2a3f5f"},"error_y":{"color":"#2a3f5f"},"marker":{"line":{"color":"#E5ECF6","width":0.5},"pattern":{"fillmode":"overlay","size":10,"solidity":0.2}},"type":"bar"}],"scattergeo":[{"type":"scattergeo","marker":{"colorbar":{"outlinewidth":0,"ticks":""}}}],"scatterpolar":[{"type":"scatterpolar","marker":{"colorbar":{"outlinewidth":0,"ticks":""}}}],"histogram":[{"marker":{"pattern":{"fillmode":"overlay","size":10,"solidity":0.2}},"type":"histogram"}],"scattergl":[{"type":"scattergl","marker":{"colorbar":{"outlinewidth":0,"ticks":""}}}],"scatter3d":[{"type":"scatter3d","line":{"colorbar":{"outlinewidth":0,"ticks":""}},"marker":{"colorbar":{"outlinewidth":0,"ticks":""}}}],"scattermapbox":[{"type":"scattermapbox","marker":{"colorbar":{"outlinewidth":0,"ticks":""}}}],"scatterternary":[{"type":"scatterternary","marker":{"colorbar":{"outlinewidth":0,"ticks":""}}}],"scattercarpet":[{"type":"scattercarpet","marker":{"colorbar":{"outlinewidth":0,"ticks":""}}}],"carpet":[{"aaxis":{"endlinecolor":"#2a3f5f","gridcolor":"white","linecolor":"white","minorgridcolor":"white","startlinecolor":"#2a3f5f"},"baxis":{"endlinecolor":"#2a3f5f","gridcolor":"white","linecolor":"white","minorgridcolor":"white","startlinecolor":"#2a3f5f"},"type":"carpet"}],"table":[{"cells":{"fill":{"color":"#EBF0F8"},"line":{"color":"white"}},"header":{"fill":{"color":"#C8D4E3"},"line":{"color":"white"}},"type":"table"}],"barpolar":[{"marker":{"line":{"color":"#E5ECF6","width":0.5},"pattern":{"fillmode":"overlay","size":10,"solidity":0.2}},"type":"barpolar"}],"pie":[{"automargin":true,"type":"pie"}]},"layout":{"autotypenumbers":"strict","colorway":["#636efa","#EF553B","#00cc96","#ab63fa","#FFA15A","#19d3f3","#FF6692","#B6E880","#FF97FF","#FECB52"],"font":{"color":"#2a3f5f"},"hovermode":"closest","hoverlabel":{"align":"left"},"paper_bgcolor":"white","plot_bgcolor":"#E5ECF6","polar":{"bgcolor":"#E5ECF6","angularaxis":{"gridcolor":"white","linecolor":"white","ticks":""},"radialaxis":{"gridcolor":"white","linecolor":"white","ticks":""}},"ternary":{"bgcolor":"#E5ECF6","aaxis":{"gridcolor":"white","linecolor":"white","ticks":""},"baxis":{"gridcolor":"white","linecolor":"white","ticks":""},"caxis":{"gridcolor":"white","linecolor":"white","ticks":""}},"coloraxis":{"colorbar":{"outlinewidth":0,"ticks":""}},"colorscale":{"sequential":[[0.0,"#0d0887"],[0.1111111111111111,"#46039f"],[0.2222222222222222,"#7201a8"],[0.3333333333333333,"#9c179e"],[0.4444444444444444,"#bd3786"],[0.5555555555555556,"#d8576b"],[0.6666666666666666,"#ed7953"],[0.7777777777777778,"#fb9f3a"],[0.8888888888888888,"#fdca26"],[1.0,"#f0f921"]],"sequentialminus":[[0.0,"#0d0887"],[0.1111111111111111,"#46039f"],[0.2222222222222222,"#7201a8"],[0.3333333333333333,"#9c179e"],[0.4444444444444444,"#bd3786"],[0.5555555555555556,"#d8576b"],[0.6666666666666666,"#ed7953"],[0.7777777777777778,"#fb9f3a"],[0.8888888888888888,"#fdca26"],[1.0,"#f0f921"]],"diverging":[[0,"#8e0152"],[0.1,"#c51b7d"],[0.2,"#de77ae"],[0.3,"#f1b6da"],[0.4,"#fde0ef"],[0.5,"#f7f7f7"],[0.6,"#e6f5d0"],[0.7,"#b8e186"],[0.8,"#7fbc41"],[0.9,"#4d9221"],[1,"#276419"]]},"xaxis":{"gridcolor":"white","linecolor":"white","ticks":"","title":{"standoff":15},"zerolinecolor":"white","automargin":true,"zerolinewidth":2},"yaxis":{"gridcolor":"white","linecolor":"white","ticks":"","title":{"standoff":15},"zerolinecolor":"white","automargin":true,"zerolinewidth":2},"scene":{"xaxis":{"backgroundcolor":"#E5ECF6","gridcolor":"white","linecolor":"white","showbackground":true,"ticks":"","zerolinecolor":"white","gridwidth":2},"yaxis":{"backgroundcolor":"#E5ECF6","gridcolor":"white","linecolor":"white","showbackground":true,"ticks":"","zerolinecolor":"white","gridwidth":2},"zaxis":{"backgroundcolor":"#E5ECF6","gridcolor":"white","linecolor":"white","showbackground":true,"ticks":"","zerolinecolor":"white","gridwidth":2}},"shapedefaults":{"line":{"color":"#2a3f5f"}},"annotationdefaults":{"arrowcolor":"#2a3f5f","arrowhead":0,"arrowwidth":1},"geo":{"bgcolor":"white","landcolor":"#E5ECF6","subunitcolor":"white","showland":true,"showlakes":true,"lakecolor":"white"},"title":{"x":0.05},"mapbox":{"style":"light"},"margin":{"b":0,"l":0,"r":0,"t":30}}},"geo":{"domain":{"x":[0,0.48],"y":[0.0,1.0]},"projection":{"type":"mercator","scale":40},"center":{"lat":39.9,"lon":-75.1},"visible":false,"bgcolor":"rgb(201, 201, 201)","landcolor":"rgb(201, 201, 201)","lakecolor":"rgb(201, 201, 201)","showocean":true,"oceancolor":"rgb(136, 136, 136)"},"geo2":{"domain":{"x":[0.52,1],"y":[0.0,1.0]},"projection":{"type":"mercator","scale":40},"center":{"lat":39.9,"lon":-75.1},"visible":false,"bgcolor":"rgb(201, 201, 201)","landcolor":"rgb(201, 201, 201)","lakecolor":"rgb(201, 201, 201)","showocean":true,"oceancolor":"rgb(136, 136, 136)"},"annotations":[{"font":{"size":16},"showarrow":false,"text":"Actual employment","x":0.225,"xanchor":"center","xref":"paper","y":1.0,"yanchor":"bottom","yref":"paper"},{"font":{"size":16},"showarrow":false,"text":"Employment without minimum wage changes","x":0.775,"xanchor":"center","xref":"paper","y":1.0,"yanchor":"bottom","yref":"paper"}],"font":{"family":"Arial","color":"black"},"title":{"font":{"color":"black","size":20},"text":"\u003cb\u003eRealized vs. Counterfactual Employment\u003c\u002fb\u003e","x":0.03,"xanchor":"left","y":0.97,"yanchor":"top"},"margin":{"l":20,"r":20,"t":60,"b":20},"width":1150,"height":550,"plot_bgcolor":"whitesmoke","paper_bgcolor":"whitesmoke"},                        {"responsive": true}                    ).then(function(){
                             
-var gd = document.getElementById('3e60cb46-ff64-4acb-9dec-4294d609c856');
+var gd = document.getElementById('4555fc04-0498-4221-bbd4-25270f722487');
 var x = new MutationObserver(function (mutations, observer) {{
         var display = window.getComputedStyle(gd).display;
         if (!display || display === 'none') {{
@@ -1323,7 +1304,7 @@ Y_{it} = \alpha_i + \gamma SP_{it} + \delta D_{i2} + U_{it}
 <section id="estimation-of-differenced-equation" class="slide level4 scrollable">
 <h4>Estimation of Differenced Equation</h4>
 <p>Differenced equation — easy to estimate with <code>OLS</code> in <code>statsmodels</code></p>
-<div id="7c386b6d" class="cell" data-execution_count="6">
+<div id="e87007ce" class="cell" data-execution_count="6">
 <details class="code-fold">
 <summary>Regression with differenced equation</summary>
 <div class="sourceCode cell-code" id="cb6"><pre class="sourceCode numberSource python number-lines code-with-copy"><code class="sourceCode python"><span id="cb6-1"><a></a>endog <span class="op">=</span> ck_data.groupby(by<span class="op">=</span><span class="st">"store"</span>)[<span class="st">"emp_ft"</span>].diff().dropna()</span>
@@ -1341,8 +1322,8 @@ Y_{it} = \alpha_i + \gamma SP_{it} + \delta D_{i2} + U_{it}
 Dep. Variable:                 emp_ft   R-squared:                       0.015
 Model:                            OLS   Adj. R-squared:                  0.012
 Method:                 Least Squares   F-statistic:                     4.246
-Date:                Mon, 02 Jun 2025   Prob (F-statistic):             0.0400
-Time:                        19:29:15   Log-Likelihood:                -1385.7
+Date:                Fri, 06 Jun 2025   Prob (F-statistic):             0.0400
+Time:                        08:19:28   Log-Likelihood:                -1385.7
 No. Observations:                 384   AIC:                             2775.
 Df Residuals:                     382   BIC:                             2783.
 Df Model:                           1                                         
@@ -1373,7 +1354,7 @@ Notes:
 <li class="fragment">Can estimate without differencing data ourselves using <code>linearmodels</code> or <code>pyfixest</code> (more details in next lecture)</li>
 <li class="fragment">Here use <code>PanelOLS</code> from <code>linearmodels</code> with <code>entity_effects</code> (<span class="math inline">\(\alpha_i\)</span>) and <code>time_effects</code> (<span class="math inline">\(\gamma\)</span>)</li>
 </ul>
-<div id="1e2b897d" class="cell" data-execution_count="7">
+<div id="1ddfa8bf" class="cell" data-execution_count="7">
 <details class="code-fold">
 <summary>Estimation using <code>linearmodels</code></summary>
 <div class="sourceCode cell-code" id="cb8"><pre class="sourceCode numberSource python number-lines code-with-copy"><code class="sourceCode python"><span id="cb8-1"><a></a>ck_data <span class="op">=</span> ck_data.reset_index().set_index([<span class="st">"store"</span>, <span class="st">"time"</span>])</span>
@@ -1396,8 +1377,8 @@ Notes:
 Dep. Variable:                 emp_ft   R-squared:                        0.0147
 Estimator:                   PanelOLS   R-squared (Between):              0.0865
 No. Observations:                 768   R-squared (Within):              -0.0506
-Date:                Mon, Jun 02 2025   R-squared (Overall):              0.0813
-Time:                        19:29:15   Log-likelihood                   -2239.1
+Date:                Fri, Jun 06 2025   R-squared (Overall):              0.0813
+Time:                        08:19:28   Log-likelihood                   -2239.1
 Cov. Estimator:                Robust                                           
                                         F-statistic:                      5.6903
 Entities:                         384   P-value                           0.0175
@@ -1445,7 +1426,7 @@ Included effects: Entity, Time</code></pre>
 <li class="fragment">Find similar effect</li>
 </ul>
 <div class="fragment">
-<div id="3697f41c" class="cell" data-execution_count="8">
+<div id="12a11a26" class="cell" data-execution_count="8">
 <details class="code-fold">
 <summary>Adding linear covariates to TWFE DiD regression</summary>
 <div class="sourceCode cell-code" id="cb10"><pre class="sourceCode numberSource python number-lines code-with-copy"><code class="sourceCode python"><span id="cb10-1"><a></a>exog <span class="op">=</span> pd.DataFrame(exog)</span>
@@ -1463,8 +1444,8 @@ Included effects: Entity, Time</code></pre>
 Dep. Variable:                 emp_ft   R-squared:                        0.0312
 Estimator:                   PanelOLS   R-squared (Between):              0.8836
 No. Observations:                 761   R-squared (Within):              -0.0262
-Date:                Mon, Jun 02 2025   R-squared (Overall):              0.8501
-Time:                        19:29:15   Log-likelihood                   -2203.5
+Date:                Fri, Jun 06 2025   R-squared (Overall):              0.8501
+Time:                        08:19:28   Log-likelihood                   -2203.5
 Cov. Estimator:                Robust                                           
                                         F-statistic:                      6.0137
 Entities:                         384   P-value                           0.0027

--- a/docs/slides/panel/did.qmd
+++ b/docs/slides/panel/did.qmd
@@ -499,7 +499,7 @@ If parallel trends hold for all possible $\bx$, can also identify the overall ($
 Often see <span class="highlight">linearity assumptions</span> on the causal model in the form:
 $$
 \begin{aligned}
-Y_{it}^d = Y_{it}^0 + d(Y_{i2}^1- Y_{i2}^0) + \bX_{it}'\bbeta_i
+Y_{it}^d = Y_{it}^0 + d(Y_{it}^1- Y_{it}^0) + \bX_{it}'\bbeta_i
 \end{aligned}
 $$
 
@@ -507,7 +507,7 @@ $$
 
 Can estimate ATT consistently from TWFE regression
 $$
-Y_{i2}-Y_{i1} = \gamma + \delta D_{it} + (\bX_{i2}-\bX_{i1})'\bbeta + u_{it},
+Y_{i2}-Y_{i1} = \gamma + \delta D_{it} + (\bX_{i2}-\bX_{i1})'\bbeta + U_{it},
 $$
 if $\bbeta$ appropriately defined (think of OLS estimator under heterogeneous coefficient causal model)
 
@@ -517,16 +517,16 @@ Can accommodate more periods of data
 
 - $T\geq 2$
 - Two groups: never treated ($U$) and treated, treatment starts between $t_0-1$ and $t_0$
-- Treatment indicators $D_{it\tau}$, $t, \tau=1,\dots, T$: 
-  - Untreated units have $D_{it\tau}=0$ for all $t, \tau$
-  - Treated units $D_{it\tau}=1$ if and only if $t=\tau$ and $t\geq t_0$
+- Treatment indicators $D_{it, \tau}$, $t, \tau=1,\dots, T$: 
+  - Untreated units have $D_{it, \tau}=0$ for all $t, \tau$
+  - Treated units $D_{it, \tau}=1$ if and only if $t=\tau$ and $t\geq t_0$
  
 #### Adding More Periods: TWFE
 
 Multi-period specification:
 $$ \small
 \begin{aligned}
-Y_{it} &  = \alpha_i + \gamma_t + \sum_{\tau=t_0}^T \delta_\tau D_{it\tau}  + U_{it},\\
+Y_{it} &  = \alpha_i + \gamma_t + \sum_{\tau=t_0}^T \delta_\tau D_{it, \tau}  + U_{it},\\
 \alpha_i & = Y_{i1}^0, \\
 \gamma_t & = \E[Y_{it}^0- Y_{i1}^0|T],\\
 \delta_t & = \E[Y_{it}^1- Y_{it}^0|T]

--- a/docs/slides/panel/event-studies.html
+++ b/docs/slides/panel/event-studies.html
@@ -543,8 +543,11 @@
 
   </script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js" integrity="sha512-c3Nl8+7g4LMSTdrm621y7kf9v3SDPnhxLNhcjFJbKECVnmZHTdo+IRO05sNLTH/D3vA6u1X32ehoLC7WFVdheg==" crossorigin="anonymous"></script>
+
   
+
   <script type="application/javascript">define('jquery', [],function() {return window.jQuery;})</script>
+
   <meta name="description" content="Panel data event studies: causal analysis, regression interpretation, and applications to Silicon Valley Bank collapse (lecture notes slides).">
 <meta property="og:title" content="Event Studies – Advanced Econometrics">
 <meta property="og:description" content="Panel data event studies: causal analysis, regression interpretation, and applications to Silicon Valley Bank collapse (lecture notes slides).">

--- a/src/slides/panel/did.qmd
+++ b/src/slides/panel/did.qmd
@@ -517,16 +517,16 @@ Can accommodate more periods of data
 
 - $T\geq 2$
 - Two groups: never treated ($U$) and treated, treatment starts between $t_0-1$ and $t_0$
-- Treatment indicators $D_{it\tau}$, $t, \tau=1,\dots, T$: 
-  - Untreated units have $D_{it\tau}=0$ for all $t, \tau$
-  - Treated units $D_{it\tau}=1$ if and only if $t=\tau$ and $t\geq t_0$
+- Treatment indicators $D_{it, \tau}$, $t, \tau=1,\dots, T$: 
+  - Untreated units have $D_{it, \tau}=0$ for all $t, \tau$
+  - Treated units $D_{it, \tau}=1$ if and only if $t=\tau$ and $t\geq t_0$
  
 #### Adding More Periods: TWFE
 
 Multi-period specification:
 $$ \small
 \begin{aligned}
-Y_{it} &  = \alpha_i + \gamma_t + \sum_{\tau=t_0}^T \delta_\tau D_{it\tau}  + U_{it},\\
+Y_{it} &  = \alpha_i + \gamma_t + \sum_{\tau=t_0}^T \delta_\tau D_{it, \tau}  + U_{it},\\
 \alpha_i & = Y_{i1}^0, \\
 \gamma_t & = \E[Y_{it}^0- Y_{i1}^0|T],\\
 \delta_t & = \E[Y_{it}^1- Y_{it}^0|T]

--- a/src/slides/panel/did.qmd
+++ b/src/slides/panel/did.qmd
@@ -499,7 +499,7 @@ If parallel trends hold for all possible $\bx$, can also identify the overall ($
 Often see <span class="highlight">linearity assumptions</span> on the causal model in the form:
 $$
 \begin{aligned}
-Y_{it}^d = Y_{it}^0 + d(Y_{i2}^1- Y_{i2}^0) + \bX_{it}'\bbeta_i
+Y_{it}^d = Y_{it}^0 + d(Y_{it}^1- Y_{it}^0) + \bX_{it}'\bbeta_i
 \end{aligned}
 $$
 
@@ -507,7 +507,7 @@ $$
 
 Can estimate ATT consistently from TWFE regression
 $$
-Y_{i2}-Y_{i1} = \gamma + \delta D_{it} + (\bX_{i2}-\bX_{i1})'\bbeta + u_{it},
+Y_{i2}-Y_{i1} = \gamma + \delta D_{it} + (\bX_{i2}-\bX_{i1})'\bbeta + U_{it},
 $$
 if $\bbeta$ appropriately defined (think of OLS estimator under heterogeneous coefficient causal model)
 


### PR DESCRIPTION
# Lecture: Difference-in-Differences

## Description

This PR fixes minor typographic issue in the lecture on DiD:

1. Typo in switching equation in the setting with covariates. 
2. Correcting the case on $U_{it}$.
3. Aligning time dummy notation with event study lecture.