### PR TITLE
Fix numerical issues in ML lectures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /.quarto/
 tmp/
+.DS_Store
 
 # Large datasets
 *county_quarter.tab

--- a/src/slides/prediction/classification.qmd
+++ b/src/slides/prediction/classification.qmd
@@ -1150,9 +1150,9 @@ plt.show()
 - Compute with `roc_auc_score()`:
 ```{python}
 #| echo: true
-print(f"Logit AUC: {roc_auc_score(y_train_0, y_scores_logit).round(3)}")
-print(f"SVM AUC: {roc_auc_score(y_train_0, y_scores_svm).round(3)}")
-print(f"RF AUC: {roc_auc_score(y_train_0, y_scores_rf).round(3)}")
+print(f"Logit AUC: {round(roc_auc_score(y_train_0, y_scores_logit), 3)}")
+print(f"SVM AUC: {round(roc_auc_score(y_train_0, y_scores_svm), 3)}")
+print(f"RF AUC: {round(roc_auc_score(y_train_0, y_scores_rf), 3)}")
 ```
 
 

--- a/src/slides/prediction/regression-pt2.qmd
+++ b/src/slides/prediction/regression-pt2.qmd
@@ -564,7 +564,7 @@ Very easy to create a pipeline with LASSO:
 lasso_model = Pipeline(
   [
     ("preprocessing", clone(preprocessing)),
-    ("lasso", Lasso())
+    ("lasso", Lasso(max_iter=20000))
   ]
 )
 ```
@@ -756,8 +756,9 @@ Example: tuning `alpha` in LASSO
 ```{python}
 #| echo: true
 param_grid_alpha = { 
-    "lasso__alpha": np.linspace(0, 1, 11),
+    "lasso__alpha": np.linspace(0.0001, 1, 11),
 }
+# Minimum value of alpha is 0.0001 for purely numerical reasons
 ```
 
 ::: {.footer}
@@ -821,7 +822,7 @@ cv_res_alpha.sort_values(by='rank_test_score')
 #| echo: true
 param_grid = { 
     "preprocessing__poly__degree": [1, 2, 3],
-    "lasso__alpha": np.linspace(0, 1, 11),
+    "lasso__alpha": np.linspace(0.0001, 1, 11),
 }
 ```
 - `GridSearchCV` called the same way
@@ -978,7 +979,7 @@ Training and computing training loss exactly as before:
 ```{python}
 #| echo: true
 tree.fit(X_train, y_train)
-root_mean_squared_error(y_train, tree.predict(X_train)).round(4)
+round(root_mean_squared_error(y_train, tree.predict(X_train)), 4)
 ```
 
 - We <span class="highlight">interpolated</span> the training sample — perfect prediction
@@ -1211,7 +1212,7 @@ Now only need to compute test error: final evaluation
 ```{python}
 #| echo: true
 X_test, y_test = test_set.drop("MedHouseVal", axis=1), test_set["MedHouseVal"].copy()
-root_mean_squared_error(y_test, rnd_search_cv.best_estimator_.predict(X_test)).round(4)
+round(root_mean_squared_error(y_test, rnd_search_cv.best_estimator_.predict(X_test)), 4)
 ```
  
 

--- a/src/slides/prediction/regression-pt2.qmd
+++ b/src/slides/prediction/regression-pt2.qmd
@@ -796,7 +796,7 @@ Computation: estimates 10 times for each value of $\alpha$ (110 times in total)
 #### Viewing the Results {.scrollable}
 
 - The `results_` attribute has detailed info on models fitted
-- Best approach: $\alpha\approx 0.1$. Worst: $\alpha=0$ (OLS)
+- Best approach: $\alpha\approx 0.1$. Worst: $\alpha\approx 0$ (~OLS)
 
 ```{python}
 #| echo: true
@@ -858,7 +858,7 @@ cv_res.sort_values(by='rank_test_score').head(3).loc[:,
        'rank_test_score']] 
 ```
 
-- Best model: OLS with no polynomials
+- Best model: ~OLS with no polynomials
 - Close second and third: $\alpha=0.1$ and polynomials of degrees 2 and 3 
 
 
@@ -1241,8 +1241,6 @@ In this lecture we
    2. Regression trees and random forests
 
 #### Next Questions
-
-<br>
 
 Many topics open up:  
 


### PR DESCRIPTION
## Description

As noted in #91, some slides had issues with rounding in the following lectures:

- Classification
- Regression part 2

Furthermore, lasso algorithms complained about being passed `alpha=0`.

## Changes

This PR resolves the above numerical issues and updates the slides appropriately. Rounding is now applied with a function instead of a method, and the lower bound of the grid for `alpha` is a very small positive number. 

Closes #91.